### PR TITLE
Update Dates.cs

### DIFF
--- a/ExtensionMethods/Dates.cs
+++ b/ExtensionMethods/Dates.cs
@@ -75,7 +75,7 @@ namespace Umbraco.Community.ExtensionMethods.Dates
         /// </summary>
         /// <param name="day">The date</param>
         /// <returns>
-        /// 	<c>true</c> if the specified day is weekday; otherwise, <c>false</c>.
+        ///     <c>true</c> if the specified day is weekday; otherwise, <c>false</c>.
         /// </returns>
         public static bool IsWeekday(this DateTime date)
         {
@@ -156,13 +156,8 @@ namespace Umbraco.Community.ExtensionMethods.Dates
         /// <returns>
         /// Return the total number of seconds between Unix epoch and the specified date/time.
         /// </returns>
-        public static double ToUnixTime(this DateTime date)
-        {
-            // set the Unix epoch
-            var unixEpoch = new DateTime(1970, 1, 1);
-
-            // return the total seconds (from either specified date or current date/time).
-            return (date - unixEpoch).TotalSeconds;
+        public static double ToUnixTime(this DateTime date) {
+            return (date.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
         }
 
         /// <summary>


### PR DESCRIPTION
The ToUnixTime() method assumed the current timezone as GMT 0. The method now corrently converts the specified DateTime to universal time. The start of the UNIX epoch is now also based on UTC rather than the current timezone.

Another thing with the method ToUnixTime(). The return type is a double, but the scenarios I can think of, I would only need a long (no decimals). Is there a particular reason for the return type being a double?
